### PR TITLE
Added Exception Handlers to Prevent Bot Crashes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,13 @@ import "dotenv/config";
 import { initialize } from "./commands/chat/poe";
 import Client from "./structures/client";
 
+process.on('uncaughtException', (error) => {
+	console.error(`Uncaught Exception: ${error.message}`);
+});
+process.on('unhandledRejection', (error) => {
+	if (error instanceof Error) console.error(`Unhandled Rejection: ${error.message}`);
+});
+
 (async () => {
 	await initialize();
 	const client = new Client();


### PR DESCRIPTION
I've added exception handlers that will prevent the bot from crashing when encountering unexpected errors. Instead of shutting down, the bot will now be able to handle errors gracefully and continue running, without the need for manual intervention.